### PR TITLE
Export RpcDaemon settings

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -254,6 +254,7 @@ func makeCRpcDaemonSettings(settings RpcDaemonSettings) (*C.struct_SilkwormRpcSe
 		ws_enabled:                    C.bool(settings.WebSocketEnabled),
 		ws_compression:                C.bool(settings.WebSocketCompression),
 		http_compression:              C.bool(settings.HTTPCompression),
+		skip_internal_protocol_check:  C.bool(false), // We do check internal protocol versions at startup for sanity
 	}
 	if !C.go_string_copy(settings.EthAPIHost, &cSettings.eth_api_host[0], C.SILKWORM_RPC_SETTINGS_HOST_SIZE) {
 		return nil, errors.New("makeCRpcDaemonSettings failed to copy EthAPIHost")

--- a/bindings_stub.go
+++ b/bindings_stub.go
@@ -15,7 +15,7 @@ var ErrInvalidBlock = errors.New("invalid block")
 type Silkworm struct {
 }
 
-func New(dataDirPath string, libMdbxVersion string) (*Silkworm, error) {
+func New(dataDirPath string, libMdbxVersion string, numIOContexts uint32, logVerbosity uint8) (*Silkworm, error) {
 	return nil, errors.New("silkworm is not supported")
 }
 

--- a/bindings_stub.go
+++ b/bindings_stub.go
@@ -12,10 +12,12 @@ import (
 var ErrInterrupted = errors.New("interrupted")
 var ErrInvalidBlock = errors.New("invalid block")
 
+type SilkwormLogLevel uint8
+
 type Silkworm struct {
 }
 
-func New(dataDirPath string, libMdbxVersion string, numIOContexts uint32, logVerbosity uint8) (*Silkworm, error) {
+func New(dataDirPath string, libMdbxVersion string, numIOContexts uint32, logVerbosity SilkwormLogLevel) (*Silkworm, error) {
 	return nil, errors.New("silkworm is not supported")
 }
 

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	silkworm, err := New(t.TempDir(), "")
+	silkworm, err := New(t.TempDir(), "", 10, 0)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR improves the configuration support for Silkworm bindings by

- expanding the general configuration settings with `logVerbosity` and `numIOContexts`
- exporting RpcDaemon-specific configuration settings

Associated PRs:

- https://github.com/erigontech/silkworm/pull/1968